### PR TITLE
Add a down-pointing triangle to select

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -161,7 +161,7 @@ export default class ModalDropdown extends Component {
             <View style={styles.button}>
               <Text style={[styles.buttonText, this.props.textStyle]}
                     numberOfLines={1}>
-                {this.state.buttonText}
+                {this.state.buttonText} ▾
               </Text>
             </View>
           )


### PR DESCRIPTION
In order to know that the component is a select, I would suggest to add a down-pointing triangle.
Also, I would suggest an option to remove the fixed height in the dropdown very suitable for dropdowns with few options. 
  dropdown: {
    position: 'absolute',
    //height: (33 + StyleSheet.hairlineWidth) * 5,